### PR TITLE
Add class selector "devise-bs" for top-level divs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Devise Bootstrap Views
 
+## Important: What fix this fork?
+Forms are stretched to take reasonable part of viewport. Maybe it is better to add class selector to change style as you wish using SCSS, but this approach fits for my project.
+Maybe someday I'll make it more flexible.
+
+Gene.
+
+##...so, now continue original Readme:
+
 Here are some of the highlights:
 
 * Devise views with Bootstrap 3.

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -16,3 +17,4 @@
 </div>
 
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -22,3 +23,4 @@
   </div>
 </div>
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -15,3 +16,4 @@
   </div>
 </div>
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -29,3 +30,4 @@
 <p><%= t('.unhappy', :default => 'Unhappy') %>? <%= link_to t('.cancel_my_account', :default => "Cancel my account"), registration_path(resource_name), :data => { :confirm => t('.are_you_sure', :default => "Are you sure?") }, :method => :delete %>.</p>
 
 <%= link_to t('.back', :default => 'Back'), :back %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -22,3 +23,4 @@
   </div>
 </div>
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <div class="panel panel-default">
   <div class="panel-heading">
     <h4><%= t('.sign_in', :default => "Sign in") %></h4>
@@ -25,3 +26,4 @@
   </div>
 </div>
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,3 +1,4 @@
+<%= bootstrap_top %>
 <%= bootstrap_devise_error_messages! %>
 <div class="panel panel-default">
   <div class="panel-heading">
@@ -14,3 +15,4 @@
   </div>
 </div>
 <%= render "devise/shared/links" %>
+<%= bootstrap_bottom %>

--- a/lib/devise_bootstrap_views_helper.rb
+++ b/lib/devise_bootstrap_views_helper.rb
@@ -19,4 +19,16 @@ module DeviseBootstrapViewsHelper
 
     html.html_safe
   end
+
+  def bootstrap_top
+    html = <<-HTML
+    <row><div class="col-sm-3"></div><div class="col-xs-12 col-sm-6">
+    HTML
+  end
+
+  def bootstrap_bottom
+    html = <<-HTML
+    </div><div class="col-sm-3"></div></row>
+    HTML
+  end
 end


### PR DESCRIPTION
It is for ability to style forms (e.g. use only part of viewport): in case element not have unique class it is hard to style it. It is needed manually fix generated views or use JS. Now it is easy to style forms using stylesheets.
